### PR TITLE
Create atlasjs.css

### DIFF
--- a/atlasjs.css
+++ b/atlasjs.css
@@ -1,0 +1,661 @@
+/* required styles */
+
+.atlas-pane,
+.atlas-tile,
+.atlas-marker-icon,
+.atlas-marker-shadow,
+.atlas-tile-container,
+.atlas-pane > svg,
+.atlas-pane > canvas,
+.atlas-zoom-box,
+.atlas-image-layer,
+.atlas-layer {
+	position: absolute;
+	left: 0;
+	top: 0;
+	}
+.atlas-container {
+	overflow: hidden;
+	}
+.atlas-tile,
+.atlas-marker-icon,
+.atlas-marker-shadow {
+	-webkit-user-select: none;
+	   -moz-user-select: none;
+	        user-select: none;
+	  -webkit-user-drag: none;
+	}
+/* Prevents IE11 from highlighting tiles in blue */
+.atlas-tile::selection {
+	background: transparent;
+}
+/* Safari renders non-retina tile on retina better with this, but Chrome is worse */
+.atlas-safari .atlas-tile {
+	image-rendering: -webkit-optimize-contrast;
+	}
+/* hack that prevents hw layers "stretching" when loading new tiles */
+.atlas-safari .atlas-tile-container {
+	width: 1600px;
+	height: 1600px;
+	-webkit-transform-origin: 0 0;
+	}
+.atlas-marker-icon,
+.atlas-marker-shadow {
+	display: block;
+	}
+/* .atlas-container svg: reset svg max-width decleration shipped in Joomla! (joomla.org) 3.x */
+/* .atlas-container img: map is broken in FF if you have max-width: 100% on tiles */
+.atlas-container .atlas-overlay-pane svg {
+	max-width: none !important;
+	max-height: none !important;
+	}
+.atlas-container .atlas-marker-pane img,
+.atlas-container .atlas-shadow-pane img,
+.atlas-container .atlas-tile-pane img,
+.atlas-container img.atlas-image-layer,
+.atlas-container .atlas-tile {
+	max-width: none !important;
+	max-height: none !important;
+	width: auto;
+	padding: 0;
+	}
+
+.atlas-container img.atlas-tile {
+	/* See: https://bugs.chromium.org/p/chromium/issues/detail?id=600120 */
+	mix-blend-mode: plus-lighter;
+}
+
+.atlas-container.atlas-touch-zoom {
+	-ms-touch-action: pan-x pan-y;
+	touch-action: pan-x pan-y;
+	}
+.atlas-container.atlas-touch-drag {
+	-ms-touch-action: pinch-zoom;
+	/* Fallback for FF which doesn't support pinch-zoom */
+	touch-action: none;
+	touch-action: pinch-zoom;
+}
+.atlas-container.atlas-touch-drag.atlas-touch-zoom {
+	-ms-touch-action: none;
+	touch-action: none;
+}
+.atlas-container {
+	-webkit-tap-highlight-color: transparent;
+}
+.atlas-container a {
+	-webkit-tap-highlight-color: rgba(51, 181, 229, 0.4);
+}
+.atlas-tile {
+	filter: inherit;
+	visibility: hidden;
+	}
+.atlas-tile-loaded {
+	visibility: inherit;
+	}
+.atlas-zoom-box {
+	width: 0;
+	height: 0;
+	-moz-box-sizing: border-box;
+	     box-sizing: border-box;
+	z-index: 800;
+	}
+/* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */
+.atlas-overlay-pane svg {
+	-moz-user-select: none;
+	}
+
+.atlas-pane         { z-index: 400; }
+
+.atlas-tile-pane    { z-index: 200; }
+.atlas-overlay-pane { z-index: 400; }
+.atlas-shadow-pane  { z-index: 500; }
+.atlas-marker-pane  { z-index: 600; }
+.atlas-tooltip-pane   { z-index: 650; }
+.atlas-popup-pane   { z-index: 700; }
+
+.atlas-map-pane canvas { z-index: 100; }
+.atlas-map-pane svg    { z-index: 200; }
+
+.atlas-vml-shape {
+	width: 1px;
+	height: 1px;
+	}
+.atlas-vml {
+	behavior: url(#default#VML);
+	display: inline-block;
+	position: absolute;
+	}
+
+
+/* control positioning */
+
+.atlas-control {
+	position: relative;
+	z-index: 800;
+	pointer-events: visiblePainted; /* IE 9-10 doesn't have auto */
+	pointer-events: auto;
+	}
+.atlas-top,
+.atlas-bottom {
+	position: absolute;
+	z-index: 1000;
+	pointer-events: none;
+	}
+.atlas-top {
+	top: 0;
+	}
+.atlas-right {
+	right: 0;
+	}
+.atlas-bottom {
+	bottom: 0;
+	}
+.atlas-left {
+	left: 0;
+	}
+.atlas-control {
+	float: left;
+	clear: both;
+	}
+.atlas-right .atlas-control {
+	float: right;
+	}
+.atlas-top .atlas-control {
+	margin-top: 10px;
+	}
+.atlas-bottom .atlas-control {
+	margin-bottom: 10px;
+	}
+.atlas-left .atlas-control {
+	margin-left: 10px;
+	}
+.atlas-right .atlas-control {
+	margin-right: 10px;
+	}
+
+
+/* zoom and fade animations */
+
+.atlas-fade-anim .atlas-popup {
+	opacity: 0;
+	-webkit-transition: opacity 0.2s linear;
+	   -moz-transition: opacity 0.2s linear;
+	        transition: opacity 0.2s linear;
+	}
+.atlas-fade-anim .atlas-map-pane .atlas-popup {
+	opacity: 1;
+	}
+.atlas-zoom-animated {
+	-webkit-transform-origin: 0 0;
+	    -ms-transform-origin: 0 0;
+	        transform-origin: 0 0;
+	}
+svg.atlas-zoom-animated {
+	will-change: transform;
+}
+
+.atlas-zoom-anim .atlas-zoom-animated {
+	-webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1);
+	   -moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1);
+	        transition:         transform 0.25s cubic-bezier(0,0,0.25,1);
+	}
+.atlas-zoom-anim .atlas-tile,
+.atlas-pan-anim .atlas-tile {
+	-webkit-transition: none;
+	   -moz-transition: none;
+	        transition: none;
+	}
+
+.atlas-zoom-anim .atlas-zoom-hide {
+	visibility: hidden;
+	}
+
+
+/* cursors */
+
+.atlas-interactive {
+	cursor: pointer;
+	}
+.atlas-grab {
+	cursor: -webkit-grab;
+	cursor:    -moz-grab;
+	cursor:         grab;
+	}
+.atlas-crosshair,
+.atlas-crosshair .atlas-interactive {
+	cursor: crosshair;
+	}
+.atlas-popup-pane,
+.atlas-control {
+	cursor: auto;
+	}
+.atlas-dragging .atlas-grab,
+.atlas-dragging .atlas-grab .atlas-interactive,
+.atlas-dragging .atlas-marker-draggable {
+	cursor: move;
+	cursor: -webkit-grabbing;
+	cursor:    -moz-grabbing;
+	cursor:         grabbing;
+	}
+
+/* marker & overlays interactivity */
+.atlas-marker-icon,
+.atlas-marker-shadow,
+.atlas-image-layer,
+.atlas-pane > svg path,
+.atlas-tile-container {
+	pointer-events: none;
+	}
+
+.atlas-marker-icon.atlas-interactive,
+.atlas-image-layer.atlas-interactive,
+.atlas-pane > svg path.atlas-interactive,
+svg.atlas-image-layer.atlas-interactive path {
+	pointer-events: visiblePainted; /* IE 9-10 doesn't have auto */
+	pointer-events: auto;
+	}
+
+/* visual tweaks */
+
+.atlas-container {
+	background: #ddd;
+	outline-offset: 1px;
+	}
+.atlas-container a {
+	color: #0078A8;
+	}
+.atlas-zoom-box {
+	border: 2px dotted #38f;
+	background: rgba(255,255,255,0.5);
+	}
+
+
+/* general typography */
+.atlas-container {
+	font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
+	font-size: 12px;
+	font-size: 0.75rem;
+	line-height: 1.5;
+	}
+
+
+/* general toolbar styles */
+
+.atlas-bar {
+	box-shadow: 0 1px 5px rgba(0,0,0,0.65);
+	border-radius: 4px;
+	}
+.atlas-bar a {
+	background-color: #fff;
+	border-bottom: 1px solid #ccc;
+	width: 26px;
+	height: 26px;
+	line-height: 26px;
+	display: block;
+	text-align: center;
+	text-decoration: none;
+	color: black;
+	}
+.atlas-bar a,
+.atlas-control-layers-toggle {
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+	display: block;
+	}
+.atlas-bar a:hover,
+.atlas-bar a:focus {
+	background-color: #f4f4f4;
+	}
+.atlas-bar a:first-child {
+	border-top-left-radius: 4px;
+	border-top-right-radius: 4px;
+	}
+.atlas-bar a:last-child {
+	border-bottom-left-radius: 4px;
+	border-bottom-right-radius: 4px;
+	border-bottom: none;
+	}
+.atlas-bar a.atlas-disabled {
+	cursor: default;
+	background-color: #f4f4f4;
+	color: #bbb;
+	}
+
+.atlas-touch .atlas-bar a {
+	width: 30px;
+	height: 30px;
+	line-height: 30px;
+	}
+.atlas-touch .atlas-bar a:first-child {
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	}
+.atlas-touch .atlas-bar a:last-child {
+	border-bottom-left-radius: 2px;
+	border-bottom-right-radius: 2px;
+	}
+
+/* zoom control */
+
+.atlas-control-zoom-in,
+.atlas-control-zoom-out {
+	font: bold 18px 'Lucida Console', Monaco, monospace;
+	text-indent: 1px;
+	}
+
+.atlas-touch .atlas-control-zoom-in, .atlas-touch .atlas-control-zoom-out  {
+	font-size: 22px;
+	}
+
+
+/* layers control */
+
+.atlas-control-layers {
+	box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+	background: #fff;
+	border-radius: 5px;
+	}
+.atlas-control-layers-toggle {
+	background-image: url(images/layers.png);
+	width: 36px;
+	height: 36px;
+	}
+.atlas-retina .atlas-control-layers-toggle {
+	background-image: url(images/layers-2x.png);
+	background-size: 26px 26px;
+	}
+.atlas-touch .atlas-control-layers-toggle {
+	width: 44px;
+	height: 44px;
+	}
+.atlas-control-layers .atlas-control-layers-list,
+.atlas-control-layers-expanded .atlas-control-layers-toggle {
+	display: none;
+	}
+.atlas-control-layers-expanded .atlas-control-layers-list {
+	display: block;
+	position: relative;
+	}
+.atlas-control-layers-expanded {
+	padding: 6px 10px 6px 6px;
+	color: #333;
+	background: #fff;
+	}
+.atlas-control-layers-scrollbar {
+	overflow-y: scroll;
+	overflow-x: hidden;
+	padding-right: 5px;
+	}
+.atlas-control-layers-selector {
+	margin-top: 2px;
+	position: relative;
+	top: 1px;
+	}
+.atlas-control-layers label {
+	display: block;
+	font-size: 13px;
+	font-size: 1.08333em;
+	}
+.atlas-control-layers-separator {
+	height: 0;
+	border-top: 1px solid #ddd;
+	margin: 5px -10px 5px -6px;
+	}
+
+/* Default icon URLs */
+.atlas-default-icon-path { /* used only in path-guessing heuristic, see L.Icon.Default */
+	background-image: url(images/marker-icon.png);
+	}
+
+
+/* attribution and scale controls */
+
+.atlas-container .atlas-control-attribution {
+	background: #fff;
+	background: rgba(255, 255, 255, 0.8);
+	margin: 0;
+	}
+.atlas-control-attribution,
+.atlas-control-scale-line {
+	padding: 0 5px;
+	color: #333;
+	line-height: 1.4;
+	}
+.atlas-control-attribution a {
+	text-decoration: none;
+	}
+.atlas-control-attribution a:hover,
+.atlas-control-attribution a:focus {
+	text-decoration: underline;
+	}
+.atlas-attribution-flag {
+	display: inline !important;
+	vertical-align: baseline !important;
+	width: 1em;
+	height: 0.6669em;
+	}
+.atlas-left .atlas-control-scale {
+	margin-left: 5px;
+	}
+.atlas-bottom .atlas-control-scale {
+	margin-bottom: 5px;
+	}
+.atlas-control-scale-line {
+	border: 2px solid #777;
+	border-top: none;
+	line-height: 1.1;
+	padding: 2px 5px 1px;
+	white-space: nowrap;
+	-moz-box-sizing: border-box;
+	     box-sizing: border-box;
+	background: rgba(255, 255, 255, 0.8);
+	text-shadow: 1px 1px #fff;
+	}
+.atlas-control-scale-line:not(:first-child) {
+	border-top: 2px solid #777;
+	border-bottom: none;
+	margin-top: -2px;
+	}
+.atlas-control-scale-line:not(:first-child):not(:last-child) {
+	border-bottom: 2px solid #777;
+	}
+
+.atlas-touch .atlas-control-attribution,
+.atlas-touch .atlas-control-layers,
+.atlas-touch .atlas-bar {
+	box-shadow: none;
+	}
+.atlas-touch .atlas-control-layers,
+.atlas-touch .atlas-bar {
+	border: 2px solid rgba(0,0,0,0.2);
+	background-clip: padding-box;
+	}
+
+
+/* popup */
+
+.atlas-popup {
+	position: absolute;
+	text-align: center;
+	margin-bottom: 20px;
+	}
+.atlas-popup-content-wrapper {
+	padding: 1px;
+	text-align: left;
+	border-radius: 12px;
+	}
+.atlas-popup-content {
+	margin: 13px 24px 13px 20px;
+	line-height: 1.3;
+	font-size: 13px;
+	font-size: 1.08333em;
+	min-height: 1px;
+	}
+.atlas-popup-content p {
+	margin: 17px 0;
+	margin: 1.3em 0;
+	}
+.atlas-popup-tip-container {
+	width: 40px;
+	height: 20px;
+	position: absolute;
+	left: 50%;
+	margin-top: -1px;
+	margin-left: -20px;
+	overflow: hidden;
+	pointer-events: none;
+	}
+.atlas-popup-tip {
+	width: 17px;
+	height: 17px;
+	padding: 1px;
+
+	margin: -10px auto 0;
+	pointer-events: auto;
+
+	-webkit-transform: rotate(45deg);
+	   -moz-transform: rotate(45deg);
+	    -ms-transform: rotate(45deg);
+	        transform: rotate(45deg);
+	}
+.atlas-popup-content-wrapper,
+.atlas-popup-tip {
+	background: white;
+	color: #333;
+	box-shadow: 0 3px 14px rgba(0,0,0,0.4);
+	}
+.atlas-container a.atlas-popup-close-button {
+	position: absolute;
+	top: 0;
+	right: 0;
+	border: none;
+	text-align: center;
+	width: 24px;
+	height: 24px;
+	font: 16px/24px Tahoma, Verdana, sans-serif;
+	color: #757575;
+	text-decoration: none;
+	background: transparent;
+	}
+.atlas-container a.atlas-popup-close-button:hover,
+.atlas-container a.atlas-popup-close-button:focus {
+	color: #585858;
+	}
+.atlas-popup-scrolled {
+	overflow: auto;
+	}
+
+.atlas-oldie .atlas-popup-content-wrapper {
+	-ms-zoom: 1;
+	}
+.atlas-oldie .atlas-popup-tip {
+	width: 24px;
+	margin: 0 auto;
+
+	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
+	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
+	}
+
+.atlas-oldie .atlas-control-zoom,
+.atlas-oldie .atlas-control-layers,
+.atlas-oldie .atlas-popup-content-wrapper,
+.atlas-oldie .atlas-popup-tip {
+	border: 1px solid #999;
+	}
+
+
+/* div icon */
+
+.atlas-div-icon {
+	background: #fff;
+	border: 1px solid #666;
+	}
+
+
+/* Tooltip */
+/* Base styles for the element that has a tooltip */
+.atlas-tooltip {
+	position: absolute;
+	padding: 6px;
+	background-color: #fff;
+	border: 1px solid #fff;
+	border-radius: 3px;
+	color: #222;
+	white-space: nowrap;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	pointer-events: none;
+	box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+	}
+.atlas-tooltip.atlas-interactive {
+	cursor: pointer;
+	pointer-events: auto;
+	}
+.atlas-tooltip-top:before,
+.atlas-tooltip-bottom:before,
+.atlas-tooltip-left:before,
+.atlas-tooltip-right:before {
+	position: absolute;
+	pointer-events: none;
+	border: 6px solid transparent;
+	background: transparent;
+	content: "";
+	}
+
+/* Directions */
+
+.atlas-tooltip-bottom {
+	margin-top: 6px;
+}
+.atlas-tooltip-top {
+	margin-top: -6px;
+}
+.atlas-tooltip-bottom:before,
+.atlas-tooltip-top:before {
+	left: 50%;
+	margin-left: -6px;
+	}
+.atlas-tooltip-top:before {
+	bottom: 0;
+	margin-bottom: -12px;
+	border-top-color: #fff;
+	}
+.atlas-tooltip-bottom:before {
+	top: 0;
+	margin-top: -12px;
+	margin-left: -6px;
+	border-bottom-color: #fff;
+	}
+.atlas-tooltip-left {
+	margin-left: -6px;
+}
+.atlas-tooltip-right {
+	margin-left: 6px;
+}
+.atlas-tooltip-left:before,
+.atlas-tooltip-right:before {
+	top: 50%;
+	margin-top: -6px;
+	}
+.atlas-tooltip-left:before {
+	right: 0;
+	margin-right: -12px;
+	border-left-color: #fff;
+	}
+.atlas-tooltip-right:before {
+	left: 0;
+	margin-left: -12px;
+	border-right-color: #fff;
+	}
+
+/* Printing */
+
+@media print {
+	/* Prevent printers from removing background-images of controls. */
+	.atlas-control {
+		-webkit-print-color-adjust: exact;
+		print-color-adjust: exact;
+		}
+	}


### PR DESCRIPTION
This commit introduces the new `atlasjs.css` file. The content is based on the original `leaflet.css`, with all instances of "leaflet" replaced by "atlas" to align with the new Atlas.js library branding.